### PR TITLE
Play/Pause tray button, KPOP tray button & Gateway adjustment

### DIFF
--- a/src/assets/worker/websocket.worker.js
+++ b/src/assets/worker/websocket.worker.js
@@ -7,7 +7,7 @@ function heartbeat(ws, interval) {
 }
 
 function connect() {
-	let ws = new WebSocket('wss://listen.moe/beta_gateway');
+	let ws = new WebSocket('wss://listen.moe/gateway_v2');
 
 	ws.onopen = () => {
 		console.log('%c> Websocket connection established.', 'color: #008000;');

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -461,6 +461,9 @@ export default {
 		},
 		loggedIn() {
 			this.buildTray();
+		},
+		radioType() {
+			this.buildTray();
 		}
 	},
 	mounted() {
@@ -502,9 +505,7 @@ export default {
 			const menu = new Menu();
 			menu.append(new MenuItem(
 				{
-					label: 'Switch to kpop',
-					type: 'checkbox',
-					checked: this.isJpop ? false : true,
+					label: this.radioType === 'jpop' ? 'Switch to kpop' : 'Switch to jpop',
 					click: () => {
 						if (this.radioType === 'kpop') this.$store.commit('radioType', 'jpop');
 						else this.$store.commit('radioType', 'kpop');

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -464,6 +464,10 @@ export default {
 		},
 		radioType() {
 			this.buildTray();
+			if (this.playing) {
+				this.togglePlaying();
+				this.togglePlaying();
+			}
 		},
 		playing() {
 			this.buildTray();

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -464,6 +464,9 @@ export default {
 		},
 		radioType() {
 			this.buildTray();
+		},
+		playing() {
+			this.buildTray();
 		}
 	},
 	mounted() {
@@ -503,6 +506,12 @@ export default {
 		},
 		buildMenu() {
 			const menu = new Menu();
+			menu.append(new MenuItem(
+				{
+					label: this.playing ? 'Pause' : 'Play',
+					click: () => this.togglePlaying()
+				}
+			));
 			menu.append(new MenuItem(
 				{
 					label: this.radioType === 'jpop' ? 'Switch to kpop' : 'Switch to jpop',


### PR DESCRIPTION
- Adds a play/pause tray button with label based on playing status
- Changed stream switch to also update label depending on current stream
- Player now pauses and resumes automatically if stream is switched while currently playing

For the last point, it simply calls the playing toggle twice. Let me know if you'd like to have this done differently, I wasn't sure how to do it any other way.

Demo (has sound): https://i.robflop.me/rpch3tesb5mn.webm

The song info does not currently update to the kpop stream's info, talked about this with Crawl beforehand and decided to leave it like this for now (as that was the behavior before my changes as well). 