### PR TITLE
Pause/Resume Discord Presence when playback is paused/resumed

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -77,6 +77,7 @@ async function createWindow() {
 	await rpc.login({ clientId: '383375119827075072' });
 
 	ipcMain.on('updateDiscordActivity', (_, arg) => rpc.setActivity(arg));
+	ipcMain.on('clearDiscordActivity', () => rpc.clearActivity());
 
 	ipcMain.on('loginModal', () => {
 		if (loginModal) return loginModal.show();

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -26,7 +26,7 @@
 		&.gaps {
 			grid-gap: 5px;
 		}
-		
+
 		&:not(.gaps) > .shadow { box-shadow: none; }
 
 		.playButton {
@@ -456,7 +456,7 @@ export default {
 	watch: {
 		async websocket() {
 			if (this.loggedIn) await this.checkFavorite();
-			this.updateDiscordActivity();
+			if (this.playing) this.updateDiscordActivity();
 			if (this.$refs && this.$refs.slider) this.$nextTick(() => this.$refs.slider.refresh());
 		},
 		loggedIn() {
@@ -633,6 +633,7 @@ export default {
 			MUSIC_VISUALS.stop();
 			player.currentTime = 0;
 			player.src = '';
+			ipcRenderer.send('clearDiscordActivity');
 		},
 		getSource() {
 			const isKpop = this.radioType === 'kpop' ? 'kpop/' : '';

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -626,6 +626,21 @@ export default {
 				player.play();
 				MUSIC_VISUALS.start();
 				this.$store.commit('playing', true);
+				const artists = this.currentArtists.reduce((out, artist) => {
+					out += `${this.preferRomaji ? artist.nameRomaji ? artist.nameRomaji : artist.name ? artist.name : artist.nameRomaji : artist.name ? artist.name : artist.nameRomaji}${this.currentArtists.length > 1 ? ', ' : ''}`;
+					return out;
+				}, '');
+				ipcRenderer.send('updateDiscordActivity', {
+					details: this.currentSong.name.length >= 50 ? this.currentSong.name.substring(0, 50) : this.currentSong.name,
+					state: artists.length >= 50 ? artists.substring(0, 50) : artists,
+					startTimestamp: new Date(this.websocket.startTime).getTime(),
+					endTimestamp: new Date(this.websocket.startTime).getTime() + new Date(this.websocket.song.duration * 1000).getTime(),
+					largeImageKey: 'jpop',
+					largeImageText: 'LISTEN.moe',
+					smallImageKey: 'play',
+					smallImageText: 'Playing',
+					instance: false
+				});
 				return;
 			}
 			player.pause();

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -626,21 +626,7 @@ export default {
 				player.play();
 				MUSIC_VISUALS.start();
 				this.$store.commit('playing', true);
-				const artists = this.currentArtists.reduce((out, artist) => {
-					out += `${this.preferRomaji ? artist.nameRomaji ? artist.nameRomaji : artist.name ? artist.name : artist.nameRomaji : artist.name ? artist.name : artist.nameRomaji}${this.currentArtists.length > 1 ? ', ' : ''}`;
-					return out;
-				}, '');
-				ipcRenderer.send('updateDiscordActivity', {
-					details: this.currentSong.name.length >= 50 ? this.currentSong.name.substring(0, 50) : this.currentSong.name,
-					state: artists.length >= 50 ? artists.substring(0, 50) : artists,
-					startTimestamp: new Date(this.websocket.startTime).getTime(),
-					endTimestamp: new Date(this.websocket.startTime).getTime() + new Date(this.websocket.song.duration * 1000).getTime(),
-					largeImageKey: 'jpop',
-					largeImageText: 'LISTEN.moe',
-					smallImageKey: 'play',
-					smallImageText: 'Playing',
-					instance: false
-				});
+				this.updateDiscordActivity();
 				return;
 			}
 			player.pause();


### PR DESCRIPTION
Currently the desktop app will take over your Discord presence as long as it is opened, even when you are not using it actively (playback paused, program idling).

The reason for this pull request is that I'd prefer that the program that I am actively using is displayed in my Discord status.

Functionality-wise, this PR accomplishes the following:
 - When the Pause button is triggered, the User's Discord presence is cleared
 - When the playback is resumed, the User's Discord presence will again be populated with the radio's now playing information

Please let me know if there are any questions regarding the way this is implemented.
