### PR TITLE
fix: window positioning if either X or Y is 0

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -16,7 +16,7 @@ async function createWindow() {
 	const store = new Store({
 		defaults: {
 			windowSize: [800, 80],
-			windowPosition: []
+			windowPosition: [null, null]
 		}
 	});
 
@@ -30,8 +30,8 @@ async function createWindow() {
 		minWidth: 400,
 		height: 80,
 		minHeight: 80,
-		x: pos ? pos[0] ? pos[0] : null : null,
-		y: pos ? pos[1] ? pos[1] : null : null,
+		x: pos[0],
+		y: pos[1],
 		frame: false,
 		transparent: true,
 		webPreferences: {


### PR DESCRIPTION
With the current implementation of window position restoring, you get unexpected behavior if either your X or Y position is right at the edge of your screen (i.e. 0).

Since the check whether a pre-set position exists ([``src/background.js#L33``](https://github.com/LISTEN-moe/desktop-app/blob/master/src/background.js#L33) and [``src/background.js#L34``](https://github.com/LISTEN-moe/desktop-app/blob/master/src/background.js#L33) in master, prior to this PR) use a Boolean check, they interpret a position of "0" as "There is no saved position" and thus use a null value.

This means that the window does not show up at the saved position, but in the center of the screen (at least from my tests).

To fix this I've set the default store values for the window position to `[null, null]` and instead made the BrowserWindow always use the store item values. The previous faulty Boolean check for these values is thus not needed any longer and the problem is solved.

PR is tested and works. Window position is properly restored for positions including 0 X/Y values and non-zero X/Y values.