### PR TITLE
Prevent negative Y rebound from causing a syntax error

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -66,6 +66,9 @@ async function createWindow() {
 
 	win.on('move', async () => {
 		const values = win.getPosition();
+		if (values[1] < 0) values[1] = 0;
+		// Negative Y-Coordinate rebound happens automatically already, but seems to cause a syntax error in the settings json.
+		// Therefore it is manually set to 0 before being saved to the settings.
 		await store.set('windowPosition', values);
 	});
 


### PR DESCRIPTION
This PR fixes the behavior described in #11. 

The Y-Coordinate of the window is now always set to 0 if negative, and only then saved to the settings file.

Additionally, I added a comment explaining the behavior as I imagine it's not immediately clear why this is being done if not aware of the reasoning already.

I am still unsure why the automatic window rebound causes the duplication of ``]}`` at the end of the settings json, but if the coordinate is manually set to 0 this behavior does not occur anymore.