### PR TITLE
Add favorite/unfavorite toggle to tray

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "listen.moe-desktop-app",
 	"description": "It's time to ditch other radios",
-	"version": "0.2.7",
+	"version": "0.2.9",
 	"main": "background.js",
 	"private": true,
 	"author": {

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -578,7 +578,7 @@ export default {
 				{
 					label: (this.websocket && this.websocket.song && this.websocket.song.favorite) ? 'Unfavorite song' : 'Favorite song',
 					click: () => this.toggleFavorite(),
-					enabled: this.loggedIn ? true : false
+					enabled: this.loggedIn
 				}
 			));
 			menu.append(new MenuItem(

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -506,9 +506,6 @@ export default {
 		},
 		playing() {
 			this.buildTray();
-		},
-		toggleFavorite() {
-			this.buildTray();
 		}
 	},
 	mounted() {
@@ -579,7 +576,7 @@ export default {
 			));
 			menu.append(new MenuItem(
 				{
-					label: this.checkFavorite() ? 'Unfavorite song' : 'Favorite song',
+					label: (this.websocket && this.websocket.song && this.websocket.song.favorite) ? 'Unfavorite song' : 'Favorite song',
 					click: () => this.toggleFavorite(),
 					enabled: this.loggedIn ? true : false
 				}
@@ -726,6 +723,7 @@ export default {
 					}
 				});
 				this.websocket.song.favorite = !Boolean(this.websocket.song.favorite);
+				this.buildTray();
 				this.$forceUpdate();
 			} catch (error) {
 				// TODO: Proper feedback

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -492,6 +492,7 @@ export default {
 			if (this.loggedIn) await this.checkFavorite();
 			if (this.playing) this.updateDiscordActivity();
 			if (this.$refs && this.$refs.slider) this.$nextTick(() => this.$refs.slider.refresh());
+			this.buildTray();
 		},
 		loggedIn() {
 			this.buildTray();
@@ -504,6 +505,9 @@ export default {
 			}
 		},
 		playing() {
+			this.buildTray();
+		},
+		toggleFavorite() {
 			this.buildTray();
 		}
 	},
@@ -549,10 +553,16 @@ export default {
 		},
 		buildMenu() {
 			const menu = new Menu();
-      menu.append(new MenuItem(
+
+			menu.append(new MenuItem(
 				{
 					label: 'Open LISTEN.moe',
 					click: () => ipcRenderer.send('show-tray')
+				}
+			));
+			menu.append(new MenuItem(
+				{
+					type: 'separator'
 				}
 			));
 			menu.append(new MenuItem(
@@ -569,9 +579,20 @@ export default {
 			));
 			menu.append(new MenuItem(
 				{
-					label: 'Settings', click() {
-						ipcRenderer.send('settingsModal');
-					}
+					label: this.checkFavorite() ? 'Unfavorite song' : 'Favorite song',
+					click: () => this.toggleFavorite(),
+					enabled: this.loggedIn ? true : false
+				}
+			));
+			menu.append(new MenuItem(
+				{
+					type: 'separator'
+				}
+			));
+			menu.append(new MenuItem(
+				{
+					label: 'Settings',
+					click: () => ipcRenderer.send('settingsModal')
 				}
 			));
 			menu.append(new MenuItem(
@@ -713,7 +734,7 @@ export default {
 		},
 		buildTray() {
 			if (!this.tray) this.tray = new Tray(join(__static, 'logo-trans.png'));
-			this.tray.setToolTip('LISTEN.moe')
+			this.tray.setToolTip('LISTEN.moe');
 			this.tray.setContextMenu(this.buildMenu());
 		}
 	}

--- a/src/components/player/index.vue
+++ b/src/components/player/index.vue
@@ -516,7 +516,7 @@ export default {
 
 		this.buildTray();
 
-		this.tray.on('double-click', () => ipcRenderer.send('show-tray'));
+		this.tray.on('click', () => ipcRenderer.send('show-tray'));
 
 		MUSIC_VISUALS = {
 			start: () => {


### PR DESCRIPTION
As per request in Discord

- Adds a button to favorite/unfavorite the currently playing song to the tray menu
- Adds separators between context menu item sections: Open window, playback buttons, settings, quit
- Makes the main window appear on single-click on tray (previously double-click)
- Updates version number in package.json to 0.2.9