### PR TITLE
fix: Discord RPC dead code

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -171,6 +171,9 @@ async function createWindow() {
 		win.webContents.send('playerOptionsChange', arg);
 	});
 
+	rpc.on('ready', () => rpcReady = true);
+	rpc.login({ clientId: '383375119827075072' });
+
 	try {
 		const github = await fetch('https://api.github.com/repos/LISTEN-moe/desktop-app/releases/latest');
 		const json = await github.json();
@@ -187,9 +190,6 @@ async function createWindow() {
 		});
 		if (response) shell.openExternal('https://github.com/LISTEN-moe/desktop-app/releases/latest');
 	} catch {}
-
-	rpc.on('ready', () => rpcReady = true);
-	rpc.login({ clientId: '383375119827075072' });
 }
 
 // Disable hardware acceleration on Linux for transparent background


### PR DESCRIPTION
Fixed `rpc.on()` and `rpc.login()` dead code by moving it before the checking-for-update try-catch block.

Both never ran when app version is the latest since `app.getVersion() === json.name` will return early.
This means RPC never logs in, `rpcReady` never sets to true and ultimately `updateDiscordActivity` never sets rich presence.

Bug observed, and fix tested on Pop!_OS 20.04 (Ubuntu 20.04).